### PR TITLE
Fix doc comment warnings in selector.rs

### DIFF
--- a/src/selector.rs
+++ b/src/selector.rs
@@ -27,22 +27,22 @@ impl Default for Selector {
     /// Defaults to implement a new selector without defining each field individually
     fn default() -> Selector {
         Selector {
-            /// Default start to 0, the first row/column
+            // Default start to 0, the first row/column
             start_idx: 0,
 
-            /// Default start to ".^", an impossible Regex that nothing will match
+            // Default start to ".^", an impossible Regex that nothing will match
             start_regex: Regex::new(r".^").unwrap(),
 
-            /// Default end to the max usize value (i.e. 2^64 - 1 on an amd64 machine)
+            // Default end to the max usize value (i.e. 2^64 - 1 on an amd64 machine)
             end_idx: std::usize::MAX,
 
-            /// Default end to ".^", an impossible Regex that nothing will match
+            // Default end to ".^", an impossible Regex that nothing will match
             end_regex: Regex::new(r".^").unwrap(),
 
-            /// Default step to 1 to get each row
+            // Default step to 1 to get each row
             step: 1,
 
-            /// Default stopped to false so we output rows unless otherwise specified
+            // Default stopped to false so we output rows unless otherwise specified
             stopped: false,
         }
     }


### PR DESCRIPTION
## Summary
- Fixed compiler warnings about unused doc comments in `src/selector.rs`
- Changed `///` doc comments to `//` regular comments for field initializations in the Default impl

## Problem
The Rust compiler was generating warnings because doc comments (`///`) were being used on expression fields inside struct initialization, where they don't generate documentation.

## Solution
Converted all doc comments to regular comments (`//`) in the Selector Default implementation, eliminating the compiler warnings while preserving the explanatory comments.

## Test plan
- [x] Run `cargo build` - builds without warnings
- [x] Verify functionality unchanged - comments are explanatory only