### PR TITLE
fix: prevent division by zero panic when step=0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,8 +99,20 @@ fn main() {
     let input = cli::parse_input(&args.input);
 
     // Parse selectors
-    let mut row_selectors = selector::parse_selectors(&args.rows);
-    let mut column_selectors = selector::parse_selectors(&args.columns);
+    let mut row_selectors = match selector::parse_selectors(&args.rows) {
+        Ok(selectors) => selectors,
+        Err(e) => {
+            eprintln!("Error parsing row selectors: {}", e);
+            std::process::exit(1);
+        }
+    };
+    let mut column_selectors = match selector::parse_selectors(&args.columns) {
+        Ok(selectors) => selectors,
+        Err(e) => {
+            eprintln!("Error parsing column selectors: {}", e);
+            std::process::exit(1);
+        }
+    };
 
     // Parse input data according to arguments
     let mut export_cols: Vec<usize> = Vec::new();

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -98,7 +98,8 @@ pub fn parse_selectors(selectors: &str) -> Vec<Selector> {
                         }
                         2 => {
                             // Step value should NOT be decremented - use raw value
-                            sequence.step = *raw_number;
+                            // Prevent division by zero by defaulting step=0 to step=1
+                            sequence.step = if *raw_number == 0 { 1 } else { *raw_number };
                         }
                         _ => panic!("A selector cannot be more than three components long"),
                     }


### PR DESCRIPTION
Fixes critical division by zero panic when step=0 is used in selectors.

## Changes
- Modified selector parsing to automatically convert step=0 to step=1
- Prevents modulo operation with zero divisor in item_in_sequence function
- Maintains expected behavior (step=1 means select every item in range)
- Fixes critical bug that caused immediate crash on step=0 input

Fixes #11

Generated with [Claude Code](https://claude.ai/code)