### PR TITLE
fix: handle regex compilation errors gracefully

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::process;
 
 mod cli;
 mod selector;
+use selector::SelectorError;
 
 include!("utils.rs");
 
@@ -55,7 +56,7 @@ pub fn get_columns(
     index_row: &str,
     column_selectors: &mut [selector::Selector],
     column_delimiter: &str,
-) -> Result<Vec<usize>, String> {
+) -> Result<Vec<usize>, SelectorError> {
     if column_selectors.is_empty() {
         // Return blank vector if no column selectors present
         Ok(Vec::new())
@@ -79,7 +80,7 @@ pub fn get_columns(
 
 /// Grab cells in a row by a list of given indeces
 #[cfg_attr(test, allow(dead_code))]
-pub fn get_cells(row: &str, cells_to_select: &[usize], column_delimiter: &str) -> Result<Vec<String>, String> {
+pub fn get_cells(row: &str, cells_to_select: &[usize], column_delimiter: &str) -> Result<Vec<String>, SelectorError> {
     if cells_to_select.is_empty() {
         // If no cells to select specified, return one element vector of the row
         Ok(vec![row.to_string()])

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use std::process;
 
 mod cli;
 mod selector;
@@ -54,15 +55,16 @@ pub fn get_columns(
     index_row: &str,
     column_selectors: &mut [selector::Selector],
     column_delimiter: &str,
-) -> Vec<usize> {
+) -> Result<Vec<usize>, String> {
     if column_selectors.is_empty() {
         // Return blank vector if no column selectors present
-        Vec::new()
+        Ok(Vec::new())
     } else {
         // Return a vector of column indices to export
         let mut export_column_idxs: Vec<usize> = Vec::new();
         // Iterate through columns in first row
-        for (col_idx, column) in utils::split(index_row, column_delimiter).iter().enumerate() {
+        let columns = utils::split(index_row, column_delimiter)?;
+        for (col_idx, column) in columns.iter().enumerate() {
             // Iterate through selector in vector of selectors
             for column_selector in column_selectors.iter_mut() {
                 if item_in_sequence(col_idx, column, column_selector) {
@@ -71,25 +73,26 @@ pub fn get_columns(
             }
         }
         // Return indexes of matched columns
-        export_column_idxs
+        Ok(export_column_idxs)
     }
 }
 
 /// Grab cells in a row by a list of given indeces
 #[cfg_attr(test, allow(dead_code))]
-pub fn get_cells(row: &str, cells_to_select: &[usize], column_delimiter: &str) -> Vec<String> {
+pub fn get_cells(row: &str, cells_to_select: &[usize], column_delimiter: &str) -> Result<Vec<String>, String> {
     if cells_to_select.is_empty() {
         // If no cells to select specified, return one element vector of the row
-        vec![row.to_string()]
+        Ok(vec![row.to_string()])
     } else {
         // Iterate through cells in row and push ones with matching indeces to output vector
         let mut output: Vec<String> = Vec::new();
-        for (cell_idx, cell) in utils::split(row, column_delimiter).iter().enumerate() {
+        let cells = utils::split(row, column_delimiter)?;
+        for (cell_idx, cell) in cells.iter().enumerate() {
             if cells_to_select.contains(&cell_idx) {
                 output.push(cell.clone());
             }
         }
-        output
+        Ok(output)
     }
 }
 
@@ -99,20 +102,51 @@ fn main() {
     let input = cli::parse_input(&args.input);
 
     // Parse selectors
-    let mut row_selectors = selector::parse_selectors(&args.rows);
-    let mut column_selectors = selector::parse_selectors(&args.columns);
+    let mut row_selectors = match selector::parse_selectors(&args.rows) {
+        Ok(selectors) => selectors,
+        Err(e) => {
+            eprintln!("Error parsing row selectors: {}", e);
+            process::exit(1);
+        }
+    };
+    let mut column_selectors = match selector::parse_selectors(&args.columns) {
+        Ok(selectors) => selectors,
+        Err(e) => {
+            eprintln!("Error parsing column selectors: {}", e);
+            process::exit(1);
+        }
+    };
 
     // Parse input data according to arguments
     let mut export_cols: Vec<usize> = Vec::new();
     let mut output: Vec<Vec<String>> = Vec::new();
-    let split_rows = utils::split(&input, &args.row_delimiter);
+    let split_rows = match utils::split(&input, &args.row_delimiter) {
+        Ok(rows) => rows,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    };
     for (row_idx, row) in split_rows.iter().enumerate() {
         if row_idx == 0 {
-            export_cols = get_columns(row, &mut column_selectors, &args.column_delimiter);
+            export_cols = match get_columns(row, &mut column_selectors, &args.column_delimiter) {
+                Ok(cols) => cols,
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            };
         }
         for row_selector in row_selectors.iter_mut() {
             if item_in_sequence(row_idx, row, row_selector) {
-                output.push(get_cells(row, &export_cols, &args.column_delimiter));
+                let cells = match get_cells(row, &export_cols, &args.column_delimiter) {
+                    Ok(cells) => cells,
+                    Err(e) => {
+                        eprintln!("Error: {}", e);
+                        process::exit(1);
+                    }
+                };
+                output.push(cells);
             }
         }
     }

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -108,7 +108,7 @@ mod tests {
         let mut selectors: Vec<Selector> = Vec::new();
         let delimiter = String::from(r"\s");
 
-        let result = get_columns(&row, &mut selectors, &delimiter);
+        let result = get_columns(&row, &mut selectors, &delimiter).unwrap();
         assert_eq!(result.len(), 0);
     }
 
@@ -118,7 +118,7 @@ mod tests {
         let mut selectors = parse_selectors(&String::from("2")).unwrap();
         let delimiter = String::from(r"\s");
 
-        let result = get_columns(&row, &mut selectors, &delimiter);
+        let result = get_columns(&row, &mut selectors, &delimiter).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], 1); // Column 2 is index 1
     }
@@ -129,7 +129,7 @@ mod tests {
         let mut selectors = parse_selectors(&String::from("1,3")).unwrap();
         let delimiter = String::from(r"\s");
 
-        let result = get_columns(&row, &mut selectors, &delimiter);
+        let result = get_columns(&row, &mut selectors, &delimiter).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], 0); // Column 1 is index 0
         assert_eq!(result[1], 2); // Column 3 is index 2
@@ -141,7 +141,7 @@ mod tests {
         let mut selectors = parse_selectors(&String::from("2:4")).unwrap();
         let delimiter = String::from(r"\s");
 
-        let result = get_columns(&row, &mut selectors, &delimiter);
+        let result = get_columns(&row, &mut selectors, &delimiter).unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], 1); // Column 2
         assert_eq!(result[1], 2); // Column 3
@@ -154,7 +154,7 @@ mod tests {
         let mut selectors = parse_selectors(&String::from("pid")).unwrap();
         let delimiter = String::from(r"\s");
 
-        let result = get_columns(&row, &mut selectors, &delimiter);
+        let result = get_columns(&row, &mut selectors, &delimiter).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], 1); // PID is index 1
     }
@@ -165,7 +165,7 @@ mod tests {
         let mut selectors = parse_selectors(&String::from("1,pid,%mem")).unwrap();
         let delimiter = String::from(r"\s");
 
-        let result = get_columns(&row, &mut selectors, &delimiter);
+        let result = get_columns(&row, &mut selectors, &delimiter).unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], 0); // USER is index 0
         assert_eq!(result[1], 1); // PID is index 1
@@ -178,7 +178,7 @@ mod tests {
         let mut selectors = parse_selectors(&String::from("2:3")).unwrap();
         let delimiter = String::from(",");
 
-        let result = get_columns(&row, &mut selectors, &delimiter);
+        let result = get_columns(&row, &mut selectors, &delimiter).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], 1); // col2
         assert_eq!(result[1], 2); // col3
@@ -190,7 +190,7 @@ mod tests {
         let cells_to_select: Vec<usize> = Vec::new();
         let delimiter = String::from(r"\s");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], "cell1 cell2 cell3");
     }
@@ -201,7 +201,7 @@ mod tests {
         let cells_to_select = vec![1];
         let delimiter = String::from(r"\s");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], "cell2");
     }
@@ -212,7 +212,7 @@ mod tests {
         let cells_to_select = vec![0, 2, 3];
         let delimiter = String::from(r"\s");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "cell1");
         assert_eq!(result[1], "cell3");
@@ -225,7 +225,7 @@ mod tests {
         let cells_to_select = vec![3, 1, 0];
         let delimiter = String::from(r"\s");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "A");
         assert_eq!(result[1], "B");
@@ -238,7 +238,7 @@ mod tests {
         let cells_to_select = vec![1, 3];
         let delimiter = String::from(",");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], "b");
         assert_eq!(result[1], "d");
@@ -250,7 +250,7 @@ mod tests {
         let cells_to_select = vec![0, 2];
         let delimiter = String::from(r"\t");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], "field1");
         assert_eq!(result[1], "field3");
@@ -262,7 +262,7 @@ mod tests {
         let cells_to_select = vec![0, 1];
         let delimiter = String::from(",");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], "a");
         assert_eq!(result[1], "c"); // Empty cell is filtered out
@@ -274,7 +274,7 @@ mod tests {
         let cells_to_select = vec![0, 5, 10]; // Indices beyond the row length
         let delimiter = String::from(r"\s");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], "a"); // Only the valid index is included
     }
@@ -285,7 +285,7 @@ mod tests {
         let cells_to_select = vec![0, 2];
         let delimiter = String::from(",");
 
-        let result = get_cells(&row, &cells_to_select, &delimiter);
+        let result = get_cells(&row, &cells_to_select, &delimiter).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], "hello world");
         assert_eq!(result[1], "baz qux");

--- a/src/selector_tests.rs
+++ b/src/selector_tests.rs
@@ -153,7 +153,7 @@ mod tests {
     fn test_parse_selectors_non_integer_step() {
         let result = parse_selectors(&String::from("1:10:abc"));
         assert!(result.is_err());
-        let error_msg = result.unwrap_err();
+        let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("Step size must be an integer"));
     }
 
@@ -161,7 +161,7 @@ mod tests {
     fn test_parse_selectors_too_many_components() {
         let result = parse_selectors(&String::from("1:2:3:4"));
         assert!(result.is_err());
-        let error_msg = result.unwrap_err();
+        let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("A selector cannot be more than three components long"));
     }
 
@@ -190,7 +190,7 @@ mod tests {
     fn test_parse_selectors_step_zero_error() {
         let result = parse_selectors(&String::from("1:10:0"));
         assert!(result.is_err());
-        let error_msg = result.unwrap_err();
+        let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("step size cannot be zero"));
         assert!(error_msg.contains("1:10:0"));
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 mod utils {
     use regex::Regex;
+    use crate::SelectorError;
 
     /// Test is two regex expressions are equal
     /// This needs to be done as there's no PartialEq provided by regex::Regex
@@ -19,9 +20,9 @@ mod utils {
     /// 
     /// # Errors
     /// 
-    /// Returns a formatted error string if the delimiter regex pattern fails to compile.
+    /// Returns `SelectorError::InvalidRegex` if the delimiter regex pattern fails to compile.
     #[allow(dead_code)]
-    pub fn split(text: &str, delimiter: &str) -> Result<Vec<String>, String> {
+    pub fn split(text: &str, delimiter: &str) -> Result<Vec<String>, SelectorError> {
         if delimiter.is_empty() {
             // Split by lines if empty delmiter passed. This should be faster than regex split
             Ok(text.lines()
@@ -31,7 +32,10 @@ mod utils {
         } else {
             // Split by regex
             let regex = Regex::new(delimiter)
-                .map_err(|e| format!("Invalid delimiter pattern '{}': {}", delimiter, e))?;
+                .map_err(|e| SelectorError::InvalidRegex { 
+                    pattern: delimiter.to_string(), 
+                    source: e 
+                })?;
             Ok(regex
                 .split(text)
                 .filter(|s| !s.is_empty())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,22 +16,27 @@ mod utils {
     }
 
     /// Split given text by a delimiter, returning a vector of Strings
+    /// 
+    /// # Errors
+    /// 
+    /// Returns a formatted error string if the delimiter regex pattern fails to compile.
     #[allow(dead_code)]
-    pub fn split(text: &str, delimiter: &str) -> Vec<String> {
+    pub fn split(text: &str, delimiter: &str) -> Result<Vec<String>, String> {
         if delimiter.is_empty() {
             // Split by lines if empty delmiter passed. This should be faster than regex split
-            text.lines()
+            Ok(text.lines()
                 .filter(|s| !s.is_empty())
                 .map(String::from)
-                .collect()
+                .collect())
         } else {
             // Split by regex
-            Regex::new(delimiter)
-                .unwrap()
+            let regex = Regex::new(delimiter)
+                .map_err(|e| format!("Invalid delimiter pattern '{}': {}", delimiter, e))?;
+            Ok(regex
                 .split(text)
                 .filter(|s| !s.is_empty())
                 .map(String::from)
-                .collect()
+                .collect())
         }
     }
 }

--- a/src/utils_tests.rs
+++ b/src/utils_tests.rs
@@ -46,7 +46,7 @@ mod tests {
     fn test_split_empty_delimiter() {
         let text = String::from("line1\nline2\nline3\n");
         let delimiter = String::from("");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "line1");
@@ -58,7 +58,7 @@ mod tests {
     fn test_split_empty_delimiter_with_empty_lines() {
         let text = String::from("line1\n\nline2\n\n\nline3");
         let delimiter = String::from("");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         // Empty lines should be filtered out
         assert_eq!(result.len(), 3);
@@ -71,7 +71,7 @@ mod tests {
     fn test_split_whitespace_delimiter() {
         let text = String::from("word1 word2  word3\tword4");
         let delimiter = String::from(r"\s+");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 4);
         assert_eq!(result[0], "word1");
@@ -84,7 +84,7 @@ mod tests {
     fn test_split_comma_delimiter() {
         let text = String::from("apple,banana,cherry");
         let delimiter = String::from(",");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "apple");
@@ -96,7 +96,7 @@ mod tests {
     fn test_split_pipe_delimiter() {
         let text = String::from("col1|col2|col3");
         let delimiter = String::from(r"\|");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "col1");
@@ -108,7 +108,7 @@ mod tests {
     fn test_split_tab_delimiter() {
         let text = String::from("field1\tfield2\tfield3");
         let delimiter = String::from(r"\t");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "field1");
@@ -120,7 +120,7 @@ mod tests {
     fn test_split_custom_delimiter() {
         let text = String::from("part1::part2::part3");
         let delimiter = String::from("::");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "part1");
@@ -132,7 +132,7 @@ mod tests {
     fn test_split_regex_delimiter() {
         let text = String::from("num1num2num3");
         let delimiter = String::from(r"\d+"); // Split on digits
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "num");
@@ -144,7 +144,7 @@ mod tests {
     fn test_split_filters_empty_strings() {
         let text = String::from(",,a,b,,c,,");
         let delimiter = String::from(",");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         // Empty strings should be filtered out
         assert_eq!(result.len(), 3);
@@ -157,7 +157,7 @@ mod tests {
     fn test_split_complex_multiline() {
         let text = String::from("USER     PID   %CPU  %MEM    VSZ   RSS\nroot       1    0.0   0.0  12345  6789\nuser     123    1.5   2.3  98765  4321");
         let delimiter = String::from(r"\n");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 3);
         assert!(result[0].starts_with("USER"));
@@ -170,20 +170,20 @@ mod tests {
         // Empty text
         let text = String::from("");
         let delimiter = String::from(",");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         assert_eq!(result.len(), 0);
         
         // Text with no delimiters
         let text = String::from("singleword");
         let delimiter = String::from(",");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], "singleword");
         
         // Text that is just delimiters
         let text = String::from(",,,");
         let delimiter = String::from(",");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         assert_eq!(result.len(), 0); // All empty strings filtered out
     }
 
@@ -191,7 +191,7 @@ mod tests {
     fn test_split_preserves_internal_spaces() {
         let text = String::from("hello world,foo bar,baz qux");
         let delimiter = String::from(",");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "hello world");
@@ -203,7 +203,7 @@ mod tests {
     fn test_split_default_whitespace_behavior() {
         let text = String::from("word1 word2  word3\t\tword4\n");
         let delimiter = String::from(r"\s");
-        let result = utils::split(&text, &delimiter);
+        let result = utils::split(&text, &delimiter).unwrap();
         
         // Should split on any whitespace
         assert!(result.len() >= 4);


### PR DESCRIPTION
Replace .unwrap() calls with proper error handling to prevent panics on invalid user input:

- Add SelectorError enum with clear error messages
- Update parse_selectors() to return Result<Vec<Selector>, SelectorError>
- Update utils::split() to return Result with regex validation
- Add error propagation throughout main.rs pipeline
- Graceful exit with descriptive messages instead of panics

Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/code)