### PR TITLE
test: handle Result-returning parse_selectors

### DIFF
--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
-    use crate::selector::{Selector, parse_selectors};
-    use crate::{item_in_sequence, get_columns, get_cells};
+    use crate::selector::{parse_selectors, Selector};
+    use crate::{get_cells, get_columns, item_in_sequence};
     use regex::Regex;
 
     #[test]
@@ -9,7 +9,7 @@ mod tests {
         let mut selector = Selector::default();
         selector.start_idx = 2;
         selector.end_idx = 2;
-        
+
         let item = String::from("test");
         assert!(!item_in_sequence(0, &item, &mut selector));
         assert!(!item_in_sequence(1, &item, &mut selector));
@@ -22,7 +22,7 @@ mod tests {
         let mut selector = Selector::default();
         selector.start_idx = 2;
         selector.end_idx = 5;
-        
+
         let item = String::from("test");
         assert!(!item_in_sequence(0, &item, &mut selector));
         assert!(!item_in_sequence(1, &item, &mut selector));
@@ -39,7 +39,7 @@ mod tests {
         selector.start_idx = 0;
         selector.end_idx = 10;
         selector.step = 2;
-        
+
         let item = String::from("test");
         assert!(item_in_sequence(0, &item, &mut selector));
         assert!(!item_in_sequence(1, &item, &mut selector));
@@ -57,11 +57,11 @@ mod tests {
         selector.end_regex = Regex::new(r"(?i).*pid.*").unwrap();
         selector.start_idx = usize::MAX;
         selector.end_idx = usize::MAX;
-        
+
         let pid_item = String::from("PID");
         let user_item = String::from("USER");
         let process_pid = String::from("process_pid");
-        
+
         assert!(item_in_sequence(0, &pid_item, &mut selector));
         assert!(!item_in_sequence(1, &user_item, &mut selector));
         assert!(item_in_sequence(2, &process_pid, &mut selector));
@@ -72,21 +72,21 @@ mod tests {
         let mut selector = Selector::default();
         selector.start_regex = Regex::new(r"(?i).*start.*").unwrap();
         selector.end_regex = Regex::new(r"(?i).*end.*").unwrap();
-        
+
         let start = String::from("START");
         let middle = String::from("MIDDLE");
         let end = String::from("END");
-        
+
         // Before match
         assert!(!item_in_sequence(0, &middle, &mut selector));
-        
+
         // Start match
         assert!(item_in_sequence(1, &start, &mut selector));
         assert_eq!(selector.start_idx, 1);
-        
+
         // Middle items (after start has been found)
         assert!(item_in_sequence(2, &middle, &mut selector));
-        
+
         // End match
         assert!(item_in_sequence(3, &end, &mut selector));
     }
@@ -96,7 +96,7 @@ mod tests {
         let mut selector = Selector::default();
         selector.start_idx = 2;
         selector.end_idx = 2;
-        
+
         let item = String::from("test");
         assert!(item_in_sequence(2, &item, &mut selector));
         assert!(selector.stopped); // Should be stopped after single selection
@@ -107,7 +107,7 @@ mod tests {
         let row = String::from("col1 col2 col3");
         let mut selectors: Vec<Selector> = Vec::new();
         let delimiter = String::from(r"\s");
-        
+
         let result = get_columns(&row, &mut selectors, &delimiter);
         assert_eq!(result.len(), 0);
     }
@@ -115,9 +115,9 @@ mod tests {
     #[test]
     fn test_get_columns_single_index() {
         let row = String::from("col1 col2 col3");
-        let mut selectors = parse_selectors(&String::from("2"));
+        let mut selectors = parse_selectors(&String::from("2")).unwrap();
         let delimiter = String::from(r"\s");
-        
+
         let result = get_columns(&row, &mut selectors, &delimiter);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], 1); // Column 2 is index 1
@@ -126,9 +126,9 @@ mod tests {
     #[test]
     fn test_get_columns_multiple_indices() {
         let row = String::from("col1 col2 col3 col4");
-        let mut selectors = parse_selectors(&String::from("1,3"));
+        let mut selectors = parse_selectors(&String::from("1,3")).unwrap();
         let delimiter = String::from(r"\s");
-        
+
         let result = get_columns(&row, &mut selectors, &delimiter);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], 0); // Column 1 is index 0
@@ -138,9 +138,9 @@ mod tests {
     #[test]
     fn test_get_columns_range() {
         let row = String::from("col1 col2 col3 col4");
-        let mut selectors = parse_selectors(&String::from("2:4"));
+        let mut selectors = parse_selectors(&String::from("2:4")).unwrap();
         let delimiter = String::from(r"\s");
-        
+
         let result = get_columns(&row, &mut selectors, &delimiter);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], 1); // Column 2
@@ -151,9 +151,9 @@ mod tests {
     #[test]
     fn test_get_columns_regex() {
         let row = String::from("USER PID COMMAND");
-        let mut selectors = parse_selectors(&String::from("pid"));
+        let mut selectors = parse_selectors(&String::from("pid")).unwrap();
         let delimiter = String::from(r"\s");
-        
+
         let result = get_columns(&row, &mut selectors, &delimiter);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], 1); // PID is index 1
@@ -162,9 +162,9 @@ mod tests {
     #[test]
     fn test_get_columns_mixed() {
         let row = String::from("USER PID %CPU %MEM COMMAND");
-        let mut selectors = parse_selectors(&String::from("1,pid,%mem"));
+        let mut selectors = parse_selectors(&String::from("1,pid,%mem")).unwrap();
         let delimiter = String::from(r"\s");
-        
+
         let result = get_columns(&row, &mut selectors, &delimiter);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], 0); // USER is index 0
@@ -175,9 +175,9 @@ mod tests {
     #[test]
     fn test_get_columns_custom_delimiter() {
         let row = String::from("col1,col2,col3,col4");
-        let mut selectors = parse_selectors(&String::from("2:3"));
+        let mut selectors = parse_selectors(&String::from("2:3")).unwrap();
         let delimiter = String::from(",");
-        
+
         let result = get_columns(&row, &mut selectors, &delimiter);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], 1); // col2
@@ -189,7 +189,7 @@ mod tests {
         let row = String::from("cell1 cell2 cell3");
         let cells_to_select: Vec<usize> = Vec::new();
         let delimiter = String::from(r"\s");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], "cell1 cell2 cell3");
@@ -200,7 +200,7 @@ mod tests {
         let row = String::from("cell1 cell2 cell3");
         let cells_to_select = vec![1];
         let delimiter = String::from(r"\s");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], "cell2");
@@ -211,7 +211,7 @@ mod tests {
         let row = String::from("cell1 cell2 cell3 cell4");
         let cells_to_select = vec![0, 2, 3];
         let delimiter = String::from(r"\s");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "cell1");
@@ -224,7 +224,7 @@ mod tests {
         let row = String::from("A B C D");
         let cells_to_select = vec![3, 1, 0];
         let delimiter = String::from(r"\s");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 3);
         assert_eq!(result[0], "A");
@@ -237,7 +237,7 @@ mod tests {
         let row = String::from("a,b,c,d,e");
         let cells_to_select = vec![1, 3];
         let delimiter = String::from(",");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], "b");
@@ -249,7 +249,7 @@ mod tests {
         let row = String::from("field1\tfield2\tfield3");
         let cells_to_select = vec![0, 2];
         let delimiter = String::from(r"\t");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], "field1");
@@ -261,7 +261,7 @@ mod tests {
         let row = String::from("a,,c");
         let cells_to_select = vec![0, 1];
         let delimiter = String::from(",");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], "a");
@@ -273,7 +273,7 @@ mod tests {
         let row = String::from("a b c");
         let cells_to_select = vec![0, 5, 10]; // Indices beyond the row length
         let delimiter = String::from(r"\s");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0], "a"); // Only the valid index is included
@@ -284,7 +284,7 @@ mod tests {
         let row = String::from("hello world,foo bar,baz qux");
         let cells_to_select = vec![0, 2];
         let delimiter = String::from(",");
-        
+
         let result = get_cells(&row, &cells_to_select, &delimiter);
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], "hello world");


### PR DESCRIPTION
## Summary
- unwrap `parse_selectors` results in main tests so callers handle `Result`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68ba626ca270832a8ae5ca82eeace49c