### PR TITLE
Warn on unmatched column selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ ps aux | ock -c name, pid -r "python(2|3)"
 ```
 ock  -r 1:10:2 -c 1,5 --column-delimiter "," data.csv
 ```
+
+### Out-of-bounds selections
+Selecting columns that are not present in the input produces no output and
+emits a warning.

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,21 +187,26 @@ fn main() {
         // Column selectors provided - process normally
         let mut export_cols: Vec<usize> = Vec::new();
         let mut output: Vec<Vec<String>> = Vec::new();
-        
+
         for (row_idx, row) in split_rows.iter().enumerate() {
             if row_idx == 0 {
-                export_cols = match get_columns(row, &mut column_selectors, &args.column_delimiter) {
+                export_cols = match get_columns(row, &mut column_selectors, &args.column_delimiter)
+                {
                     Ok(cols) => cols,
                     Err(e) => {
                         eprintln!("Error: {}", e);
                         process::exit(1);
                     }
                 };
+                if export_cols.is_empty() {
+                    eprintln!("Warning: No valid columns found for selection");
+                }
             }
             for row_selector in row_selectors.iter_mut() {
                 if item_in_sequence(row_idx, row, row_selector) {
                     let cells =
-                        match get_cells(row, &export_cols, &args.column_delimiter, select_full_row) {
+                        match get_cells(row, &export_cols, &args.column_delimiter, select_full_row)
+                        {
                             Ok(cells) => cells,
                             Err(e) => {
                                 eprintln!("Error: {}", e);


### PR DESCRIPTION
## Summary
- warn when column selectors do not match any columns
- document out-of-bounds selection behaviour

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68bb0e556a68832ab8ca996a50fc175f