### PR TITLE
Refactor: Remove mutable selector state during iteration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,73 @@ use selector::SelectorError;
 
 include!("utils.rs");
 
+/// Track selection state during iteration without mutating the selector
+#[derive(Debug, Clone, PartialEq)]
+pub struct SelectionState {
+    /// Current resolved start index for this iteration
+    pub current_start_idx: usize,
+    /// Current resolved end index for this iteration  
+    pub current_end_idx: usize,
+    /// Whether the selection has been stopped (for single item selections)
+    pub stopped: bool,
+}
+
+#[cfg_attr(test, allow(dead_code))]
+pub fn item_in_sequence_with_state(
+    item_idx: usize, 
+    item: &str, 
+    selector: &selector::Selector, 
+    state: &mut SelectionState,
+    collection_length: usize
+) -> bool {
+    // Create a mutable copy for index resolution (temporary compatibility)
+    let mut temp_selector = selector.clone();
+    temp_selector.resolve_indices(collection_length);
+
+    let mut in_sequence = false;
+    
+    // If a regex is provided as the only selector, just check against it
+    if item_idx != temp_selector.resolved_start_idx
+        && temp_selector.resolved_start_idx == temp_selector.resolved_end_idx
+        && utils::regex_eq(&temp_selector.start_regex, &temp_selector.end_regex)
+        && !utils::regex_is_default(&temp_selector.start_regex)
+    {
+        return temp_selector.start_regex.is_match(item);
+    }
+    
+    if (item_idx == temp_selector.resolved_start_idx && utils::regex_is_default(&temp_selector.start_regex))
+        || temp_selector.start_regex.is_match(item)
+    {
+        // Sequence started
+        in_sequence = true;
+        state.current_start_idx = item_idx;
+        if (utils::regex_eq(&temp_selector.end_regex, &temp_selector.start_regex)
+            && !utils::regex_is_default(&temp_selector.start_regex))
+            || (temp_selector.resolved_end_idx == temp_selector.resolved_start_idx)
+        {
+            // Only one column selected
+            state.stopped = true;
+        }
+    } else if state.current_start_idx != usize::MAX
+        && ((item_idx == temp_selector.resolved_end_idx
+            && item_idx >= state.current_start_idx
+            && item_idx.saturating_sub(state.current_start_idx) % temp_selector.step == 0)
+            || temp_selector.end_regex.is_match(item))
+    {
+        // Sequence end
+        in_sequence = true;
+        state.current_end_idx = item_idx;
+    } else if item_idx > state.current_start_idx
+        && item_idx < state.current_end_idx
+        && item_idx.saturating_sub(state.current_start_idx) % temp_selector.step == 0
+    {
+        // Sequence middle
+        in_sequence = true;
+    }
+    in_sequence
+}
+
+// Keep the old function for backward compatibility during transition
 #[cfg_attr(test, allow(dead_code))]
 pub fn item_in_sequence(item_idx: usize, item: &str, selector: &mut selector::Selector, collection_length: usize) -> bool {
     // Resolve indices if not already done
@@ -53,7 +120,40 @@ pub fn item_in_sequence(item_idx: usize, item: &str, selector: &mut selector::Se
     in_sequence
 }
 
-/// Get vector of columns to use from header row
+/// Get vector of columns to use from header row (immutable version)
+#[cfg_attr(test, allow(dead_code))]
+pub fn get_columns_immutable(
+    index_row: &str,
+    column_selectors: &[selector::Selector],
+    column_delimiter: &str,
+) -> Result<Vec<usize>, SelectorError> {
+    if column_selectors.is_empty() {
+        // Return blank vector if no column selectors present
+        Ok(Vec::new())
+    } else {
+        // Return a vector of column indices to export
+        let mut export_column_idxs: Vec<usize> = Vec::new();
+        // Iterate through columns in first row
+        let columns = utils::split(index_row, column_delimiter)?;
+        for (col_idx, column) in columns.iter().enumerate() {
+            // Iterate through selector in vector of selectors
+            for column_selector in column_selectors.iter() {
+                let mut state = SelectionState {
+                    current_start_idx: usize::MAX,
+                    current_end_idx: usize::MAX,
+                    stopped: false,
+                };
+                if item_in_sequence_with_state(col_idx, column, column_selector, &mut state, columns.len()) {
+                    export_column_idxs.push(col_idx);
+                }
+            }
+        }
+        // Return indexes of matched columns
+        Ok(export_column_idxs)
+    }
+}
+
+/// Get vector of columns to use from header row (backward compatibility)
 #[cfg_attr(test, allow(dead_code))]
 pub fn get_columns(
     index_row: &str,
@@ -81,7 +181,55 @@ pub fn get_columns(
     }
 }
 
-/// Get vector of columns and track which selectors matched
+/// Get vector of columns and track which selectors matched (immutable version)
+#[cfg_attr(test, allow(dead_code))]
+pub fn get_columns_with_match_info_immutable(
+    index_row: &str,
+    column_selectors: &[selector::Selector],
+    column_delimiter: &str,
+    original_selectors_str: &str,
+) -> Result<(Vec<usize>, Vec<String>), SelectorError> {
+    if column_selectors.is_empty() {
+        // Return empty vector when no column selectors provided (consistent with get_columns)
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let mut export_column_idxs: Vec<usize> = Vec::new();
+    let mut matched_selectors: Vec<bool> = vec![false; column_selectors.len()];
+    let columns = utils::split(index_row, column_delimiter)?;
+    
+    for (col_idx, column) in columns.iter().enumerate() {
+        for (selector_idx, column_selector) in column_selectors.iter().enumerate() {
+            let mut state = SelectionState {
+                current_start_idx: usize::MAX,
+                current_end_idx: usize::MAX,
+                stopped: false,
+            };
+            if item_in_sequence_with_state(col_idx, column, column_selector, &mut state, columns.len()) {
+                export_column_idxs.push(col_idx);
+                matched_selectors[selector_idx] = true;
+            }
+        }
+    }
+
+    // Collect unmatched selector strings
+    let original_parts: Vec<&str> = original_selectors_str.split(',').collect();
+    let unmatched: Vec<String> = matched_selectors
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, &matched)| {
+            if !matched && idx < original_parts.len() {
+                Some(original_parts[idx].trim().to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    Ok((export_column_idxs, unmatched))
+}
+
+/// Get vector of columns and track which selectors matched (backward compatibility)
 #[cfg_attr(test, allow(dead_code))]
 pub fn get_columns_with_match_info(
     index_row: &str,
@@ -196,14 +344,14 @@ fn main() {
     let select_full_row = args.columns.is_empty();
 
     // Parse selectors
-    let mut row_selectors = match selector::parse_selectors(&args.rows) {
+    let row_selectors = match selector::parse_selectors(&args.rows) {
         Ok(selectors) => selectors,
         Err(e) => {
             eprintln!("Error parsing row selectors: {}", e);
             process::exit(1);
         }
     };
-    let mut column_selectors = match selector::parse_selectors(&args.columns) {
+    let column_selectors = match selector::parse_selectors(&args.columns) {
         Ok(selectors) => selectors,
         Err(e) => {
             eprintln!("Error parsing column selectors: {}", e);
@@ -224,11 +372,18 @@ fn main() {
     let mut export_cols: Vec<usize> = Vec::new();
     let mut output: Vec<Vec<String>> = Vec::new();
 
+    // Track selection state for each row selector
+    let mut row_states: Vec<SelectionState> = row_selectors.iter().map(|_| SelectionState {
+        current_start_idx: usize::MAX,
+        current_end_idx: usize::MAX,
+        stopped: false,
+    }).collect();
+
     for (row_idx, row) in split_rows.iter().enumerate() {
         if row_idx == 0 {
-            let (cols, unmatched) = match get_columns_with_match_info(
+            let (cols, unmatched) = match get_columns_with_match_info_immutable(
                 row, 
-                &mut column_selectors, 
+                &column_selectors, 
                 &args.column_delimiter, 
                 &args.columns
             ) {
@@ -249,8 +404,8 @@ fn main() {
                 }
             }
         }
-        for row_selector in row_selectors.iter_mut() {
-            if item_in_sequence(row_idx, row, row_selector, split_rows.len()) {
+        for (selector_idx, row_selector) in row_selectors.iter().enumerate() {
+            if item_in_sequence_with_state(row_idx, row, row_selector, &mut row_states[selector_idx], split_rows.len()) {
                 let cells =
                     match get_cells(row, &export_cols, &args.column_delimiter, select_full_row)
                     {

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -37,7 +37,7 @@ impl std::error::Error for SelectorError {
 }
 
 /// Keep track of user column and row selections
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Selector {
     /// Index of first row to grab (start of range) - can be negative for Python-style indexing
     pub start_idx: i64,


### PR DESCRIPTION
This refactor addresses the architectural issues identified in issue #13:

- Add SelectionState struct to track match progress separately from selector definition
- Create immutable versions of key functions
- Update main function to use immutable selectors with separate state tracking
- Maintain backward compatibility with existing functions

Benefits:
- Selectors can now be reused after processing
- Thread-safe (no concurrent mutation)
- Easier testing and reasoning about code
- Follows functional programming principles

Closes #13

Generated with [Claude Code](https://claude.ai/code)