### PR TITLE
fix: avoid cache lock contention and bound regex cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +163,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -172,6 +201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "lru"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +220,7 @@ name = "ock"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "lru",
  "once_cell",
  "regex",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ panic = "abort"
 clap = { version = "4.5.4", features = ["derive"] }
 regex = "1.7.0"
 once_cell = "1.21.3"
+lru = "0.16.0"
 
 [dev-dependencies]
 tempfile = "3.8.0"

--- a/src/selector_tests.rs
+++ b/src/selector_tests.rs
@@ -285,7 +285,7 @@ mod tests {
         let r2 = get_or_compile_regex("foo_cache_test").unwrap();
         assert!(Arc::ptr_eq(&r1, &r2));
         let cache = REGEX_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-        assert!(cache.contains_key("foo_cache_test"));
+        assert!(cache.contains("foo_cache_test"));
     }
 
     #[test]
@@ -302,6 +302,6 @@ mod tests {
             assert!(Arc::ptr_eq(&results[0], r));
         }
         let cache = REGEX_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-        assert!(cache.contains_key("thread_safe_test"));
+        assert!(cache.contains("thread_safe_test"));
     }
 }


### PR DESCRIPTION
## Summary
- compile regexes outside cache mutex to reduce contention
- bound global regex cache with a 128-entry LRU to cap memory
- adapt tests for new LRU cache

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68bb4ce6fd84832ab3ff0be118a21ab0