### PR TITLE
chore: track GitHub Actions versions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds a `github-actions` ecosystem block to `.github/dependabot.yml` so Dependabot will open weekly update PRs for the pinned action versions used across the workflows in `.github/workflows/` (`ci.yml`, `release.yml`, `build-binaries.yml`).

Without this block, those pinned versions never receive automatic update PRs. Schedule matches the existing `cargo` entry (weekly).

Refs: Linear [WWM-121](https://linear.app/atemp/issue/WWM-121/add-github-actions-ecosystem-to-dependabot-configs)
Follow-up to Greptile P2 feedback on #53.